### PR TITLE
feat: Implement Child Profile Selection page and controller updates

### DIFF
--- a/lib/core/translations/app_translations.dart
+++ b/lib/core/translations/app_translations.dart
@@ -798,4 +798,10 @@ class TrKeys {
       'parentalControlDisabledTooltip';
   static const String childModeSwitchDisabledTooltip =
       'childModeSwitchDisabledTooltip';
+
+  // Nuevas claves para la selección de perfil
+  static const whoIsUsing = 'who_is_using'; // Ya existe, pero la mantengo por si acaso
+  static const parentAccessButtonTooltip = 'parent_access_button_tooltip';
+  static const noChildProfilesSelectMessage =
+      'no_child_profiles_select_message';
 }

--- a/lib/core/translations/en_translations.dart
+++ b/lib/core/translations/en_translations.dart
@@ -870,4 +870,10 @@ final Map<String, String> enTranslations = {
       "Set up your family and at least one child to enable Parental Controls.",
   'childModeSwitchDisabledTooltip':
       "Set up your family and at least one child to enable Child Mode.",
+
+  // New keys for profile selection
+  'who_is_using': 'Who are you?',
+  'parent_access_button_tooltip': 'Parent Access',
+  'no_child_profiles_select_message':
+      'Oh! It seems there are no profiles yet. Ask an adult to create one.',
 };

--- a/lib/core/translations/es_translations.dart
+++ b/lib/core/translations/es_translations.dart
@@ -888,4 +888,10 @@ final Map<String, String> esTranslations = {
       "Configura tu familia y al menos un niño para activar el Control Parental.",
   'childModeSwitchDisabledTooltip':
       "Configura tu familia y al menos un niño para activar el Modo Infantil.",
+
+  // Nuevas claves para la selección de perfil
+  'who_is_using': '¿Quién eres?',
+  'parent_access_button_tooltip': 'Acceso Padres',
+  'no_child_profiles_select_message':
+      '¡Oh! Parece que aún no hay perfiles. Pídele a un adulto que cree uno.',
 };

--- a/lib/presentation/controllers/child_access_controller.dart
+++ b/lib/presentation/controllers/child_access_controller.dart
@@ -114,6 +114,9 @@ class ChildAccessController extends GetxController {
                 !_parentalControlController.isProfileBlocked(child.id))
             .toList();
 
+        // Ordenar alfabéticamente por nombre
+        filteredChildren.sort((a, b) => a.name.compareTo(b.name));
+
         availableChildren.addAll(filteredChildren);
         status.value = ChildAccessStatus.success;
         _logger.i(
@@ -188,6 +191,7 @@ class ChildAccessController extends GetxController {
   /// Sale del modo infantil y vuelve al modo padre
   void exitChildMode() {
     isChildMode.value = false;
+    activeChildProfile.value = null; // Limpiar perfil activo
     sessionStartTime.value = null;
     timeWarningShown.value = false;
     _logger.i("Salido del modo infantil");

--- a/lib/presentation/pages/child_access/child_profile_selection_page.dart
+++ b/lib/presentation/pages/child_access/child_profile_selection_page.dart
@@ -5,497 +5,367 @@ import 'package:kidsdo/core/constants/dimensions.dart';
 import 'package:kidsdo/core/translations/app_translations.dart';
 import 'package:kidsdo/domain/entities/family_child.dart';
 import 'package:kidsdo/presentation/controllers/child_access_controller.dart';
+import 'package:kidsdo/presentation/widgets/auth/parental_pin_dialog.dart';
 import 'package:kidsdo/presentation/widgets/common/cached_avatar.dart';
 import 'package:kidsdo/routes.dart';
-import 'package:kidsdo/presentation/widgets/auth/parental_pin_dialog.dart';
 
-class ChildProfileSelectionPage extends GetView<ChildAccessController> {
-  const ChildProfileSelectionPage({Key? key}) : super(key: key);
+class ChildProfileSelectionPage extends StatefulWidget {
+  const ChildProfileSelectionPage({super.key});
+
+  @override
+  State<ChildProfileSelectionPage> createState() =>
+      _ChildProfileSelectionPageState();
+}
+
+class _ChildProfileSelectionPageState extends State<ChildProfileSelectionPage>
+    with TickerProviderStateMixin {
+  final ChildAccessController childAccessController = Get.find();
+  AnimationController? _animationController;
+  List<Animation<double>> _animations = [];
+
+  @override
+  void initState() {
+    super.initState();
+    // Initial load and animation setup
+    _loadProfilesAndAnimate();
+
+    // Listen for changes in available children to re-initialize animations
+    ever(childAccessController.availableChildren, (_) {
+      _disposeAnimationController(); // Dispose existing controller safely
+      _loadProfilesAndAnimate(); // Re-initialize animations
+    });
+  }
+
+  void _loadProfilesAndAnimate() {
+    // Ensure profiles are loaded before trying to animate
+    if (childAccessController.status.value != ChildAccessStatus.loading) {
+       childAccessController.loadAvailableChildProfiles().then((_) {
+        if (mounted && childAccessController.availableChildren.isNotEmpty) {
+          _initializeAnimations();
+        }
+      });
+    } else {
+       // If already loading, wait for it to complete via the `ever` listener or Obx
+    }
+  }
+
+  void _initializeAnimations() {
+    if (!mounted) return; // Ensure widget is still in the tree
+
+    final numberOfChildren = childAccessController.availableChildren.length;
+    if (numberOfChildren == 0) return;
+
+    _animationController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 500 + (numberOfChildren * 150)),
+    );
+
+    _animations = List.generate(
+      numberOfChildren,
+      (index) => CurvedAnimation(
+        parent: _animationController!,
+        curve: Interval(
+          (index * 150).toDouble() /
+              _animationController!.duration!.inMilliseconds,
+          (500 + index * 150).toDouble() /
+              _animationController!.duration!.inMilliseconds,
+          curve: Curves.easeOut,
+        ),
+      ),
+    );
+    _animationController!.forward();
+  }
+
+  void _disposeAnimationController() {
+    _animationController?.stop(); // Stop any ongoing animation
+    _animationController?.dispose();
+    _animationController = null;
+    _animations = [];
+  }
+
+  @override
+  void dispose() {
+    _disposeAnimationController();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    // Cargar perfiles infantiles al entrar a la página
-    if (controller.availableChildren.isEmpty) {
-      controller.loadAvailableChildProfiles();
-    }
-
     return Scaffold(
       body: SafeArea(
-        child: Obx(() {
-          // Mostrar carga
-          if (controller.status.value == ChildAccessStatus.loading) {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
-          }
-
-          // Mostrar error si hay
-          if (controller.status.value == ChildAccessStatus.error) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(AppDimensions.lg),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Icon(
-                      Icons.error_outline,
-                      size: 64,
-                      color: AppColors.error,
-                    ),
-                    const SizedBox(height: AppDimensions.md),
-                    Text(
-                      controller.errorMessage.value,
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        color: AppColors.error,
-                      ),
-                    ),
-                    const SizedBox(height: AppDimensions.lg),
-                    ElevatedButton.icon(
-                      onPressed: controller.loadAvailableChildProfiles,
-                      icon: const Icon(Icons.refresh),
-                      label: Text(TrKeys.retry.tr),
-                    ),
-                  ],
-                ),
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: Image.asset(
+                'assets/images/child_profile_selection_background.png',
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) {
+                  return Container(color: AppColors.childBlue);
+                },
               ),
-            );
-          }
+            ),
+            Column(
+              children: [
+                SizedBox(height: AppDimensions.xl),
+                Text(
+                  Tr.t(TrKeys.whoIsUsing),
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontFamily: 'Poppins',
+                    fontWeight: FontWeight.bold,
+                    fontSize: AppDimensions.fontHeading, // Using 30.0 as a fallback if needed
+                    color: Colors.white,
+                    shadows: [
+                      Shadow(
+                        blurRadius: 4.0,
+                        color: Colors.black.withOpacity(0.3),
+                        offset: const Offset(2.0, 2.0),
+                      ),
+                    ],
+                  ),
+                ),
+                SizedBox(height: AppDimensions.lg),
+                Expanded(
+                  child: Obx(() {
+                    // Re-initialize animations if controller was disposed or children changed
+                    // and we are in a success state with children
+                    if (childAccessController.status.value == ChildAccessStatus.success &&
+                        childAccessController.availableChildren.isNotEmpty &&
+                        (_animationController == null || _animations.length != childAccessController.availableChildren.length)) {
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (mounted) {
+                           _disposeAnimationController();
+                           _initializeAnimations();
+                        }
+                      });
+                    }
 
-          // No hay perfiles infantiles
-          if (controller.availableChildren.isEmpty) {
-            return _buildEmptyState();
-          }
+                    switch (childAccessController.status.value) {
+                      case ChildAccessStatus.loading:
+                      case ChildAccessStatus.initial: // Treat initial as loading for UI
+                        return const Center(
+                            child: CircularProgressIndicator(
+                                valueColor: AlwaysStoppedAnimation<Color>(
+                                    Colors.white)));
+                      case ChildAccessStatus.error:
+                        return Center(
+                          child: Padding(
+                            padding:
+                                EdgeInsets.all(AppDimensions.paddingScreen),
+                            child: Text(
+                              childAccessController.errorMessage.isNotEmpty
+                                  ? childAccessController.errorMessage.value
+                                  : Tr.t(TrKeys.unexpectedErrorMessage),
+                              style: TextStyle(
+                                  color: Colors.red.shade300,
+                                  fontSize: AppDimensions.fontLg),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        );
+                      case ChildAccessStatus.success:
+                        if (childAccessController.availableChildren.isEmpty) {
+                          return Center(
+                            child: Padding(
+                              padding:
+                                  EdgeInsets.all(AppDimensions.paddingScreen),
+                              child: Text(
+                                Tr.t(TrKeys.noChildProfilesSelectMessage),
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  fontSize: AppDimensions.fontXl,
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                          );
+                        }
 
-          // Mostrar selección de perfiles
-          return _buildProfilesSelection();
-        }),
+                        final children = childAccessController.availableChildren;
+                        
+                        // Ensure animations list matches children count, providing a fallback
+                        final currentAnimations = _animations.length == children.length
+                            ? _animations
+                            : List.generate(children.length, (_) => const AlwaysStoppedAnimation<double>(1.0));
+
+
+                        return LayoutBuilder(
+                          builder: (context, constraints) {
+                            if (children.length <= 3) {
+                              return Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceEvenly,
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                children: List.generate(
+                                  children.length,
+                                  (index) => _ChildAvatarItem(
+                                    child: children[index],
+                                    entryAnimation: currentAnimations[index],
+                                  ),
+                                ),
+                              );
+                            } else {
+                              return GridView.builder(
+                                padding: EdgeInsets.all(AppDimensions.md),
+                                gridDelegate:
+                                    SliverGridDelegateWithFixedCrossAxisCount(
+                                  crossAxisCount: 2,
+                                  childAspectRatio: 0.8,
+                                  crossAxisSpacing: AppDimensions.md,
+                                  mainAxisSpacing: AppDimensions.md,
+                                ),
+                                itemCount: children.length,
+                                itemBuilder: (context, index) {
+                                  return _ChildAvatarItem(
+                                    child: children[index],
+                                    entryAnimation: currentAnimations[index],
+                                  );
+                                },
+                              );
+                            }
+                          },
+                        );
+                    }
+                  }),
+                ),
+              ],
+            ),
+            Positioned(
+              bottom: AppDimensions.lg,
+              right: AppDimensions.lg,
+              child: IconButton(
+                icon: Icon(
+                  Icons.admin_panel_settings_outlined,
+                  color: Colors.white,
+                  size: AppDimensions.iconXl,
+                ),
+                tooltip: Tr.t(TrKeys.parentAccessButtonTooltip),
+                onPressed: () async {
+                  final result = await ParentalPinDialog.show();
+                  if (result == true) {
+                    childAccessController.exitChildMode();
+                    Get.offAllNamed(Routes.mainParent);
+                  }
+                },
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
+}
 
-  Widget _buildEmptyState() {
-    return Stack(
-      children: [
-        Center(
-          child: Padding(
-            padding: const EdgeInsets.all(AppDimensions.lg),
+class _ChildAvatarItem extends StatefulWidget {
+  final FamilyChild child;
+  final Animation<double> entryAnimation;
+
+  const _ChildAvatarItem(
+      {required this.child, required this.entryAnimation});
+
+  @override
+  State<_ChildAvatarItem> createState() => _ChildAvatarItemState();
+}
+
+class _ChildAvatarItemState extends State<_ChildAvatarItem> {
+  bool _isPressed = false;
+  final ChildAccessController childAccessController = Get.find();
+
+  Color _parseColor(String? colorString) {
+    if (colorString == null || colorString.isEmpty) {
+      return AppColors.primary; // Default color
+    }
+    try {
+      // Handles format "Color(0xffaabbcc)"
+      String valueString = colorString.split('(0x')[1].split(')')[0];
+      int value = int.parse(valueString, radix: 16);
+      return Color(value);
+    } catch (e) {
+      // Fallback for simple color names or if parsing fails
+      switch (colorString.toLowerCase()) {
+        case 'purple': return AppColors.childPurple;
+        case 'blue': return AppColors.childBlue;
+        case 'green': return AppColors.childGreen;
+        case 'orange': return AppColors.childOrange;
+        case 'pink': return AppColors.childPink;
+        case 'teal': return AppColors.childTeal;
+        default: return AppColors.primary;
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const double avatarRadius = 50.0;
+
+    Color itemColor = AppColors.primary; // Default
+    final dynamic colorSetting = widget.child.settings['color'];
+
+    if (colorSetting is Color) {
+      itemColor = colorSetting;
+    } else if (colorSetting is String) {
+      itemColor = _parseColor(colorSetting);
+    }
+
+
+    return FadeTransition(
+      opacity: widget.entryAnimation,
+      child: ScaleTransition(
+        scale: widget.entryAnimation,
+        child: GestureDetector(
+          onTapDown: (_) => setState(() => _isPressed = true),
+          onTapUp: (_) {
+            setState(() => _isPressed = false);
+            childAccessController.activateChildProfile(widget.child);
+            Get.toNamed(Routes.childDashboard); // Navigate to child dashboard
+          },
+          onTapCancel: () => setState(() => _isPressed = false),
+          child: AnimatedScale(
+            scale: _isPressed ? 0.95 : 1.0,
+            duration: const Duration(milliseconds: 150),
             child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                Container(
-                  width: 120,
-                  height: 120,
-                  decoration: BoxDecoration(
-                    color: AppColors.primary.withValues(alpha: 0.1),
-                    shape: BoxShape.circle,
+                if (widget.child.avatarUrl != null &&
+                    widget.child.avatarUrl!.isNotEmpty)
+                  CachedAvatar(
+                      url: widget.child.avatarUrl!, radius: avatarRadius)
+                else
+                  CircleAvatar(
+                    radius: avatarRadius,
+                    backgroundColor: itemColor,
+                    child: Icon(Icons.person,
+                        size: avatarRadius, color: Colors.white),
                   ),
-                  child: const Icon(
-                    Icons.child_care,
-                    size: 64,
-                    color: AppColors.primary,
-                  ),
-                ),
-                const SizedBox(height: AppDimensions.lg),
-                Text(
-                  TrKeys.noChildProfilesAccess.tr,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    fontSize: AppDimensions.fontLg,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const SizedBox(height: AppDimensions.md),
-                Text(
-                  TrKeys.noChildProfilesAccessMessage.tr,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    fontSize: AppDimensions.fontMd,
-                    color: AppColors.textMedium,
+                SizedBox(height: AppDimensions.sm),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: AppDimensions.xs),
+                  child: Text(
+                    widget.child.name,
+                    textAlign: TextAlign.center,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: AppDimensions.fontLg,
+                      fontWeight: FontWeight.w600,
+                      shadows: [
+                        Shadow(
+                          blurRadius: 2.0,
+                          color: Colors.black.withOpacity(0.5),
+                          offset: const Offset(1.0, 1.0),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ],
             ),
           ),
         ),
-
-        // Botón para volver al modo parental
-        Positioned(
-          top: AppDimensions.md,
-          right: AppDimensions.md,
-          child: _buildParentModeButton(),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildProfilesSelection() {
-    return Stack(
-      children: [
-        Column(
-          children: [
-            // Encabezado
-            Container(
-              padding: const EdgeInsets.all(AppDimensions.lg),
-              alignment: Alignment.center,
-              child: Column(
-                children: [
-                  Text(
-                    TrKeys.whoIsUsing.tr,
-                    style: const TextStyle(
-                      fontSize: AppDimensions.fontXl,
-                      fontWeight: FontWeight.bold,
-                      color: AppColors.primary,
-                    ),
-                  ),
-                  const SizedBox(height: AppDimensions.sm),
-                  Text(
-                    TrKeys.selectProfileMessage.tr,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      fontSize: AppDimensions.fontMd,
-                      color: AppColors.textMedium,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-
-            // Perfiles
-            Expanded(
-              child: GridView.builder(
-                padding: const EdgeInsets.all(AppDimensions.lg),
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 2,
-                  childAspectRatio: 0.65, // Ajustado para evitar overflow
-                  crossAxisSpacing: AppDimensions.lg,
-                  mainAxisSpacing: AppDimensions.xl,
-                ),
-                itemCount: controller.availableChildren.length,
-                itemBuilder: (context, index) {
-                  final child = controller.availableChildren[index];
-                  return _buildProfileCard(child);
-                },
-              ),
-            ),
-          ],
-        ),
-
-        // Botón para volver al modo parental
-        Positioned(
-          bottom: AppDimensions.xl,
-          left: 0,
-          right: 0,
-          child: Center(
-            child: _buildParentModeButton(),
-          ),
-        ),
-      ],
-    );
-  }
-
-  // Widget _buildProfileCard(FamilyChild child) {
-  //   // Obtener color basado en la configuración
-  //   final Color themeColor = _getProfileColor(child.settings);
-
-  //   return Card(
-  //     elevation: AppDimensions.elevationMd,
-  //     shape: RoundedRectangleBorder(
-  //       borderRadius: BorderRadius.circular(AppDimensions.borderRadiusLg),
-  //     ),
-  //     // Asegurar que el contenedor tenga un tamaño fijo para evitar overflow
-  //     child: SizedBox(
-  //       width: 180, // Ancho fijo
-  //       child: Column(
-  //         mainAxisSize:
-  //             MainAxisSize.min, // Este es importante para evitar overflow
-  //         children: [
-  //           Padding(
-  //             padding: const EdgeInsets.all(AppDimensions.md),
-  //             child: Column(
-  //               mainAxisAlignment: MainAxisAlignment.center,
-  //               children: [
-  //                 // Avatar
-  //                 Hero(
-  //                   tag: 'child_avatar_${child.id}',
-  //                   child: child.avatarUrl != null
-  //                       ? CachedAvatar(
-  //                           url: child.avatarUrl,
-  //                           radius: 50,
-  //                         )
-  //                       : CircleAvatar(
-  //                           radius: 50,
-  //                           backgroundColor: themeColor.withValues(alpha: 0.2),
-  //                           child: Icon(
-  //                             Icons.child_care,
-  //                             size: 50,
-  //                             color: themeColor,
-  //                           ),
-  //                         ),
-  //                 ),
-  //                 const SizedBox(height: AppDimensions.md),
-
-  //                 // Nombre
-  //                 Text(
-  //                   child.name,
-  //                   style: const TextStyle(
-  //                     fontSize: AppDimensions.fontLg,
-  //                     fontWeight: FontWeight.bold,
-  //                   ),
-  //                   textAlign: TextAlign.center,
-  //                   maxLines: 1,
-  //                   overflow: TextOverflow.ellipsis,
-  //                 ),
-
-  //                 // Edad
-  //                 Text(
-  //                   '${child.age} ${TrKeys.yearsOld.tr}',
-  //                   style: const TextStyle(
-  //                     fontSize: AppDimensions.fontSm,
-  //                     color: AppColors.textMedium,
-  //                   ),
-  //                 ),
-
-  //                 const SizedBox(height: AppDimensions.sm),
-  //               ],
-  //             ),
-  //           ),
-
-  //           // Botón de acceso - Modificado para evitar overflow
-  //           // Ahora usamos Material para dar estilo como un botón sin que cause overflow
-  //           Material(
-  //             color: themeColor,
-  //             borderRadius: const BorderRadius.only(
-  //               bottomLeft: Radius.circular(AppDimensions.borderRadiusLg),
-  //               bottomRight: Radius.circular(AppDimensions.borderRadiusLg),
-  //             ),
-  //             child: InkWell(
-  //               onTap: () => _selectProfile(child),
-  //               borderRadius: const BorderRadius.only(
-  //                 bottomLeft: Radius.circular(AppDimensions.borderRadiusLg),
-  //                 bottomRight: Radius.circular(AppDimensions.borderRadiusLg),
-  //               ),
-  //               child: Container(
-  //                 width: double.infinity,
-  //                 padding: const EdgeInsets.symmetric(
-  //                   vertical: AppDimensions.md,
-  //                   horizontal: AppDimensions.md,
-  //                 ),
-  //                 alignment: Alignment.center,
-  //                 child: Text(
-  //                   TrKeys.accessProfile.tr,
-  //                   style: const TextStyle(
-  //                     color: Colors.white,
-  //                     fontWeight: FontWeight.bold,
-  //                     fontSize: AppDimensions.fontMd,
-  //                   ),
-  //                 ),
-  //               ),
-  //             ),
-  //           ),
-  //         ],
-  //       ),
-  //     ),
-  //   );
-  // }
-
-  Widget _buildProfileCard(FamilyChild child) {
-    // Mantenemos la firma original sin BuildContext
-    final Color themeColor =
-        _getProfileColor(child.settings); // Asume que _getProfileColor existe
-
-    // Usar un contenedor SIN altura/anchura fija para adaptarse
-    return Container(
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(
-            AppDimensions.borderRadiusLg), // Usa tus constantes
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.1),
-            blurRadius: 4,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      // Importante: Recorta el contenido que se salga del borde redondeado
-      clipBehavior: Clip.antiAlias,
-      child: Column(
-        crossAxisAlignment:
-            CrossAxisAlignment.stretch, // Asegura que los hijos llenen el ancho
-        children: [
-          // Sección Superior (Avatar y datos) - Ocupa el 70% del espacio vertical DISPONIBLE
-          Expanded(
-            flex: 7, // Proporción 7
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                  horizontal: AppDimensions.md,
-                  vertical: AppDimensions.sm), // Usa tus constantes
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment
-                    .center, // Centra verticalmente el contenido
-                children: [
-                  // Avatar
-                  Hero(
-                    tag: 'child_avatar_${child.id}',
-                    child: child.avatarUrl != null
-                        ? CachedAvatar(
-                            // Usa tu widget CachedAvatar
-                            url: child.avatarUrl,
-                            radius: 45, // Puedes ajustar este valor
-                          )
-                        : CircleAvatar(
-                            radius: 45, // Puedes ajustar este valor
-                            backgroundColor:
-                                themeColor.withAlpha(51), // alpha 0.2
-                            child: Icon(
-                              Icons.child_care,
-                              size: 45, // Ajustar tamaño del icono
-                              color: themeColor,
-                            ),
-                          ),
-                  ),
-                  const SizedBox(
-                      height: AppDimensions.md), // Espacio (Usa tus constantes)
-
-                  // Nombre
-                  Text(
-                    child.name,
-                    style: const TextStyle(
-                      fontSize: AppDimensions.fontLg, // Usa tus constantes
-                      fontWeight: FontWeight.bold,
-                    ),
-                    textAlign: TextAlign.center,
-                    maxLines: 1, // Importante para evitar saltos de línea
-                    overflow:
-                        TextOverflow.ellipsis, // Corta el texto si es muy largo
-                  ),
-
-                  // Edad
-                  Text(
-                    '${child.age} ${TrKeys.yearsOld.tr}', // Usa tus claves de traducción
-                    style: const TextStyle(
-                      fontSize: AppDimensions.fontSm, // Usa tus constantes
-                      color: AppColors.textMedium, // Usa tus colores
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
-              ),
-            ),
-          ),
-
-          // Sección Inferior (Botón) - Ocupa el 30% del espacio vertical DISPONIBLE
-          Expanded(
-            flex: 3, // Proporción 3
-            child: Material(
-              // Usar Material para el color y el efecto ripple
-              color: themeColor,
-              // Aplicar forma SÓLO a las esquinas inferiores
-              shape: const RoundedRectangleBorder(
-                borderRadius: BorderRadius.only(
-                  bottomLeft: Radius.circular(
-                      AppDimensions.borderRadiusLg), // Usa tus constantes
-                  bottomRight: Radius.circular(
-                      AppDimensions.borderRadiusLg), // Usa tus constantes
-                ),
-              ),
-              child: InkWell(
-                // InkWell para la interacción y el efecto ripple
-                onTap: () =>
-                    _selectProfile(child), // Asume que _selectProfile existe
-                // BorderRadius para que el ripple coincida con la forma del Material
-                borderRadius: const BorderRadius.only(
-                  bottomLeft: Radius.circular(
-                      AppDimensions.borderRadiusLg), // Usa tus constantes
-                  bottomRight: Radius.circular(
-                      AppDimensions.borderRadiusLg), // Usa tus constantes
-                ),
-                child: Center(
-                  // Centra el texto dentro del botón
-                  child: Padding(
-                    // Padding interno para el texto del botón
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: AppDimensions.sm,
-                        vertical: AppDimensions.xs), // Usa tus constantes
-                    child: Text(
-                      TrKeys.accessProfile.tr, // Usa tus claves de traducción
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                        fontSize: AppDimensions.fontMd, // Usa tus constantes
-                      ),
-                      textAlign: TextAlign.center,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ],
       ),
     );
-  }
-
-  Widget _buildParentModeButton() {
-    return ElevatedButton.icon(
-      onPressed: _showParentPinDialog,
-      icon: const Icon(Icons.lock),
-      label: Text(TrKeys.parentMode.tr),
-      style: ElevatedButton.styleFrom(
-        backgroundColor: Colors.white,
-        foregroundColor: AppColors.textDark,
-        shadowColor: Colors.black26,
-        elevation: 4,
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppDimensions.lg,
-          vertical: AppDimensions.md,
-        ),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppDimensions.borderRadiusMd),
-        ),
-      ),
-    );
-  }
-
-  // Muestra el diálogo para introducir el PIN de control parental
-  void _showParentPinDialog() {
-    ParentalPinDialog.show(
-      customTitle: TrKeys.parentAccess.tr,
-      customSubtitle: TrKeys.enterParentalPinMessage.tr,
-    ).then((success) {
-      if (success) {
-        Get.offNamed(Routes.mainParent);
-      }
-    });
-  }
-
-  // Selecciona un perfil infantil y navega a su dashboard
-  void _selectProfile(FamilyChild child) {
-    controller.activateChildProfile(child).then((_) {
-      Get.offNamed(Routes.childDashboard);
-    });
-  }
-
-  // Obtiene el color correspondiente a la configuración del perfil
-  Color _getProfileColor(Map<String, dynamic> settings) {
-    final String colorKey = settings['color'] as String? ?? 'blue';
-
-    switch (colorKey) {
-      case 'purple':
-        return AppColors.childPurple;
-      case 'green':
-        return AppColors.childGreen;
-      case 'orange':
-        return AppColors.childOrange;
-      case 'pink':
-        return AppColors.childPink;
-      case 'blue':
-      default:
-        return AppColors.childBlue;
-    }
   }
 }


### PR DESCRIPTION
I've implemented the `ChildProfileSelectionPage.dart` for the KidsDo app. This page allows children to select their profile to enter "Child Mode".

Key features include:
- Display of child profiles with avatars and names.
- Responsive layout for 1-3 profiles (Row) and 4+ profiles (GridView).
- Staggered fade-in and scale-up animations for profile items.
- Tap animation on profile items.
- Navigation to `ChildDashboardPage` upon profile selection.
- "Parent Access" button with PIN dialog (`ParentalPinDialog`) to navigate to the parent section (`MainParentShellPage`) and exit child mode.
- Background image and themed styling.

Modifications in `ChildAccessController.dart`:
- Sorted available child profiles alphabetically by name.
- Ensured `activeChildProfile` is cleared when exiting child mode.
- Verified `isChildMode` and SharedPreferences updates.

Added new translation keys and their Spanish and English translations for:
- `whoIsUsing`
- `parentAccessButtonTooltip`
- `noChildProfilesSelectMessage`

Verified route definitions and asset declarations in `pubspec.yaml`.